### PR TITLE
switches to google tag manager

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -39,9 +39,12 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: `gatsby-plugin-google-tagmanager`,
       options: {
-        trackingId: `119389354-1`,
+        id: "119389354-1",
+        // Include GTM in development.
+        // Defaults to false meaning GTM will only be loaded in production.
+        includeInDevelopment: false,
       },
     },
     `gatsby-plugin-feed`,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gatsby-link": "^1.6.39",
     "gatsby-plugin-feed": "^1.3.20",
     "gatsby-plugin-google-analytics": "^1.0.31",
+    "gatsby-plugin-google-tagmanager": "^1.0.18",
     "gatsby-plugin-netlify-cms": "^2.0.1",
     "gatsby-plugin-offline": "^1.0.15",
     "gatsby-plugin-react-helmet": "^1.0.8",


### PR DESCRIPTION
TODO:
- [ ] `npm uninstall gatsby-plugin-google-analytics`